### PR TITLE
feat: Add migration to fix RLS policy for profiles

### DIFF
--- a/supabase/migrations/20250813093200_fix_profiles_rls_policy.sql
+++ b/supabase/migrations/20250813093200_fix_profiles_rls_policy.sql
@@ -1,0 +1,18 @@
+-- Drop the existing RLS policies for the profiles table to ensure a clean slate.
+-- This is to remove any old, potentially restrictive policies.
+DROP POLICY IF EXISTS "Users can view their own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profiles;
+
+-- Create a new, permissive RLS policy for selecting data from the profiles table.
+-- This policy allows users to view their own profile data, including all columns.
+CREATE POLICY "Users can view their own profile"
+  ON public.profiles FOR SELECT
+  USING (auth.uid() = id);
+
+-- Create a new, permissive RLS policy for updating data in the profiles table.
+-- This policy allows users to update their own profile data, including all columns.
+-- The WITH CHECK clause ensures that a user cannot change their profile's ID.
+CREATE POLICY "Users can update their own profile"
+  ON public.profiles FOR UPDATE
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);


### PR DESCRIPTION
This commit introduces a new database migration to fix an issue where the Google Gemini API key was not being saved correctly. The root cause was a restrictive Row-Level Security (RLS) policy on the `profiles` table that prevented the application from selecting or updating the `ai_provider` and `ai_settings` columns.

The new migration drops the old, restrictive policies and creates new, permissive ones that allow you to view and update all columns in your own profile. This ensures that the AI settings can be saved and retrieved correctly, enabling the AI features on the video details page.