### PR TITLE
fix: Manually define RPC function types to resolve build error

### DIFF
--- a/components/settings/ai-settings.tsx
+++ b/components/settings/ai-settings.tsx
@@ -15,7 +15,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Separator } from "@/components/ui/separator"
 import { useSession } from "@/contexts/session-context"
 import { supabase } from "@/lib/supabase"
-import { AiSettingsResponse } from "@/lib/types"
 
 export function AISettings() {
   const { toast } = useToast()
@@ -43,7 +42,7 @@ export function AISettings() {
       if (!session) return
 
       // Call the new RPC function to get settings
-      const { data, error } = await supabase.rpc<AiSettingsResponse>("get_ai_settings").single()
+      const { data, error } = await supabase.rpc("get_ai_settings").single()
 
       if (error) {
         console.error("Error fetching AI settings via RPC:", error)
@@ -60,7 +59,7 @@ export function AISettings() {
         // Note: The RPC function returns columns named 'provider' and 'settings'
         setSelectedProvider(data.provider || "openai")
         if (data.settings) {
-          const settings = data.settings
+          const settings = data.settings as any
           setApiKeys(settings.apiKeys || { openai: "", gemini: "", anthropic: "", mistral: "" })
           setAiSettings(settings.features || aiSettings)
         }

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -227,6 +227,22 @@ export interface Database {
           updated_at?: string
           tags?: string[]
         }
+      },
+      Functions: {
+        get_ai_settings: {
+          Args: Record<string, unknown>
+          Returns: {
+            provider: string
+            settings: Json
+          }[]
+        },
+        update_ai_settings: {
+          Args: {
+            new_provider: string
+            new_settings: Json
+          }
+          Returns: undefined
+        }
       }
     }
   }


### PR DESCRIPTION
This commit fixes a Vercel deployment failure caused by TypeScript errors.

The root cause was that the auto-generated `database.types.ts` file was not aware of the new RPC functions (`get_ai_settings`, `update_ai_settings`), leading to type mismatches during the build process.

This has been resolved by:
1. Manually adding the function definitions to the `Functions` interface in `lib/database.types.ts`.
2. Simplifying the `rpc()` call in `components/settings/ai-settings.tsx` to let TypeScript infer the types automatically from the now-correct definitions.