### PR TITLE
fix: Use upsert logic to save AI settings

### DIFF
--- a/supabase/migrations/20250816111700_add_upsert_to_update_ai_settings.sql
+++ b/supabase/migrations/20250816111700_add_upsert_to_update_ai_settings.sql
@@ -1,0 +1,19 @@
+-- This function securely updates the AI settings for the currently authenticated user.
+-- It now uses "upsert" logic (INSERT ON CONFLICT) to be more robust.
+-- If a profile row for the user does not exist, it will be created.
+-- If it already exists, it will be updated.
+CREATE OR REPLACE FUNCTION update_ai_settings(
+  new_provider TEXT,
+  new_settings JSONB
+)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO public.profiles (id, ai_provider, ai_settings, updated_at)
+  VALUES (auth.uid(), new_provider, new_settings, NOW())
+  ON CONFLICT (id)
+  DO UPDATE SET
+    ai_provider = EXCLUDED.ai_provider,
+    ai_settings = EXCLUDED.ai_settings,
+    updated_at = NOW();
+END;
+$$ LANGUAGE plpgsql SECURITY INVOKER;


### PR DESCRIPTION
This commit fixes the final issue where AI settings were not being saved for users without an existing profile row.

The `update_ai_settings` RPC function has been modified to use `INSERT ... ON CONFLICT` (an "upsert" operation). This robustly handles all cases:
- If a user profile exists, it updates the settings.
- If a user profile does not exist, it creates one with the new settings.

This ensures that the save operation is always successful.