### PR TITLE
fix: Handle unknown error type in API route catch block

### DIFF
--- a/app/api/ai/optimize/route.ts
+++ b/app/api/ai/optimize/route.ts
@@ -77,8 +77,8 @@ export async function POST(req: Request) {
     }
   } catch (error) {
     console.error('[AI_OPTIMIZE_ERROR]', error)
-    // Check for specific API key errors from Google
-    if (error.message?.includes('API key not valid')) {
+    // Type guard to check if error is an instance of Error
+    if (error instanceof Error && error.message.includes('API key not valid')) {
       return NextResponse.json({ error: 'Your Google Gemini API key is not valid. Please check it in the settings.' }, { status: 400 })
     }
     return NextResponse.json({ error: 'An unexpected error occurred while communicating with the AI provider.' }, { status: 500 })


### PR DESCRIPTION
This commit resolves a Vercel deployment failure caused by a TypeScript type error.

The error `'error' is of type 'unknown'` occurred because the code was attempting to access `error.message` without first verifying that the `error` object was an instance of `Error`.

This has been fixed by adding an `instanceof Error` type guard to the `catch` block in `app/api/ai/optimize/route.ts`. This ensures type safety and allows the project to build successfully.