### PR TITLE
fix: Use regex for more flexible API key error detection

### DIFF
--- a/app/api/ai/optimize/route.ts
+++ b/app/api/ai/optimize/route.ts
@@ -77,9 +77,9 @@ export async function POST(req: Request) {
     }
   } catch (error) {
     console.error('[AI_OPTIMIZE_ERROR]', error)
-    // Type guard to check if error is an instance of Error
-    if (error instanceof Error && error.message.includes('API key not valid')) {
-      return NextResponse.json({ error: 'Your Google Gemini API key is not valid. Please check it in the settings.' }, { status: 400 })
+    // Use a case-insensitive regex to broadly catch API key-related errors.
+    if (error instanceof Error && /API key/i.test(error.message)) {
+      return NextResponse.json({ error: 'Your Google Gemini API key seems to be invalid. Please check it in the settings.' }, { status: 400 })
     }
     return NextResponse.json({ error: 'An unexpected error occurred while communicating with the AI provider.' }, { status: 500 })
   }


### PR DESCRIPTION
This commit improves the error handling in the `/api/ai/optimize` route.

Previously, the code checked for a single, specific error message ('API key not valid'). This was too brittle and failed to catch other variations of API key errors from the Google Gemini SDK.

This has been fixed by replacing the strict string check with a case-insensitive regular expression (`/API key/i`). This will more reliably catch any error message containing 'API key', providing the user with more accurate and helpful feedback when their entered API key is invalid.