### PR TITLE
fix: Use RPC call to fetch profile on video details page

### DIFF
--- a/app/(dashboard)/videos/[videoId]/page.tsx
+++ b/app/(dashboard)/videos/[videoId]/page.tsx
@@ -130,12 +130,21 @@ export default function VideoPage() {
         }
 
         // Fetch profile data
-        const { data: profileData } = await supabase
-          .from('profiles')
-          .select('ai_provider, ai_settings')
-          .eq('id', session.user.id)
-          .single()
-        setProfile(profileData)
+        const { data: rpcData, error: rpcError } = await supabase.rpc("get_ai_settings")
+
+        if (rpcError) {
+          console.error("Error fetching profile data via RPC:", rpcError)
+          // We don't need to throw, but we can't proceed with AI features
+        }
+
+        if (rpcData && rpcData.length > 0) {
+          setProfile({
+            ai_provider: rpcData[0].provider,
+            ai_settings: rpcData[0].settings,
+          })
+        } else {
+          setProfile(null)
+        }
       } catch (error) {
         console.error('Error fetching video:', error)
         setError('Failed to load video')


### PR DESCRIPTION
This commit fixes the final remaining bug that was causing the AI generation feature to fail. The root cause was that the video details page was still using a direct `supabase.from('profiles').select()` call, which was failing silently and leading to subsequent errors.

This has been resolved by replacing the direct `select` with the robust `get_ai_settings` RPC call that is already in use on the settings page.

This ensures that the user's AI provider settings are fetched correctly, resolving the 'Only Google Gemini is currently supported' error and allowing the AI generation feature to work as intended. My sincere apologies for missing this in the previous fixes.