### PR TITLE
fix: Add null check to prevent build error

### DIFF
--- a/app/(dashboard)/videos/[videoId]/page.tsx
+++ b/app/(dashboard)/videos/[videoId]/page.tsx
@@ -235,7 +235,7 @@ export default function VideoPage() {
   const handleAIGenerate = async () => {
     if (!editedVideo) return
 
-    if (!profile?.ai_settings) {
+    if (!profile?.ai_provider || !profile.ai_settings) {
       toast({
         title: 'AI Provider Not Configured',
         description: 'Please select an AI provider and add your API key in the settings.',


### PR DESCRIPTION
This commit resolves the final Vercel deployment failure.

The error `Type 'null' cannot be used as an index type` was caused by attempting to access `apiKeys[profile.ai_provider]` when `profile.ai_provider` was null.

This has been fixed by adding a null check for `profile.ai_provider` in the guard clause within the `handleAIGenerate` function in `app/(dashboard)/videos/[videoId]/page.tsx`. This ensures the value is not null before being used as an index, resolving the TypeScript error.