### PR TITLE
fix: Handle null profile in context update function

### DIFF
--- a/contexts/profile-context.tsx
+++ b/contexts/profile-context.tsx
@@ -56,15 +56,20 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
   const updateProfile = async (newProfileData: Partial<Profile>) => {
     if (!session) throw new Error("No active session")
 
-    const currentProfile = { ...profile, ...newProfileData }
+    const updatedProfile = {
+      ai_provider: null,
+      ai_settings: null,
+      ...profile,
+      ...newProfileData,
+    }
 
     // Optimistically update the local state
-    setProfile(currentProfile)
+    setProfile(updatedProfile)
 
     try {
       const { error } = await supabase.rpc('update_ai_settings', {
-        new_provider: currentProfile.ai_provider,
-        new_settings: currentProfile.ai_settings,
+        new_provider: updatedProfile.ai_provider,
+        new_settings: updatedProfile.ai_settings,
       })
 
       if (error) {


### PR DESCRIPTION
This commit resolves the final Vercel deployment failure.

The error `Type 'undefined' is not assignable to type 'string | null'` was caused in the `updateProfile` function when spreading a potentially null `profile` object. This resulted in an object that did not match the `Profile` type.

This has been fixed by providing a default base object to the spread operation. This ensures the `updatedProfile` object always has the correct shape, resolving the TypeScript error.