### PR TITLE
fix: Add explicit type to RPC call in API route

### DIFF
--- a/app/api/ai/optimize/route.ts
+++ b/app/api/ai/optimize/route.ts
@@ -4,6 +4,11 @@ import { cookies } from 'next/headers'
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import OpenAI from 'openai'
 
+interface AiSettingsRpcResponse {
+  provider: string | null
+  settings: any | null
+}
+
 // Helper function to handle JSON parsing
 const parseJsonResponse = (text: string) => {
   try {
@@ -71,10 +76,15 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { data: profile } = await supabase.rpc('get_ai_settings')
-      .single()
+    const { data, error } = await supabase.rpc('get_ai_settings').single()
 
-    if (!profile || !profile.provider || !profile.settings) {
+    if (error || !data) {
+      return NextResponse.json({ error: 'AI provider not configured. Please configure it in the settings.' }, { status: 400 })
+    }
+
+    const profile = data as AiSettingsRpcResponse
+
+    if (!profile.provider || !profile.settings) {
       return NextResponse.json({ error: 'AI provider not configured. Please configure it in the settings.' }, { status: 400 })
     }
 


### PR DESCRIPTION
This commit resolves the final Vercel deployment failure.

The error `Property 'provider' does not exist on type '{}'` was occurring in the `/api/ai/optimize` route because the return type of the `get_ai_settings` RPC call was not being correctly inferred.

This has been fixed by adding a local interface for the response type and using a type assertion to explicitly type the data returned from the RPC call. This provides the necessary type information to the TypeScript compiler and resolves the build error.