### PR TITLE
fix: Correct syntax error in AI settings component

### DIFF
--- a/components/settings/ai-settings.tsx
+++ b/components/settings/ai-settings.tsx
@@ -189,22 +189,6 @@ export function AISettings() {
           </Button>
         </CardFooter>
       </Card>
-        <CardFooter className="flex justify-end">
-          <Button onClick={handleSaveSettings} disabled={isLoading}>
-            {isLoading ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              <>
-                <Save className="mr-2 h-4 w-4" />
-                Save API Settings
-              </>
-            )}
-          </Button>
-        </CardFooter>
-      </Card>
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
Removes a duplicated CardFooter and closing Card tag that was causing a build failure.