### PR TITLE
fix: Resolve build errors

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1,5 +1,4 @@
 import { createElement } from "react"
-import { svg } from "lit"
 
 const OpenAILogo = () =>
   createElement(


### PR DESCRIPTION
- Removes an unused import from `lib/ai-providers.ts` that was causing a build failure.
- Corrects a TypeScript type error in `components/settings/ai-settings.tsx` by rendering the provider logo as a JSX component.