### PR TITLE
fix: Add full width to main layout container

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -42,7 +42,7 @@ export default function DashboardLayout({
 
   return (
     <DashboardProvider>
-      <div className="flex min-h-screen">
+      <div className="flex min-h-screen w-full">
         <AppSidebar>
           <Sidebar />
         </AppSidebar>


### PR DESCRIPTION
This commit adds the `w-full` class to the main layout container in the dashboard to ensure that the layout is always full width.