### PR TITLE
fix: Update layout width and replace logo

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -42,7 +42,7 @@ export default function DashboardLayout({
 
   return (
     <DashboardProvider>
-      <div className="flex min-h-screen">
+      <div className="flex min-h-screen w-full">
         <AppSidebar>
           <Sidebar />
         </AppSidebar>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   title: 'YouTube AI Studio',
   description: 'AI-powered YouTube video management and analytics',
   icons: {
-    icon: '/favicon.ico',
+    icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/fd/YouTube_full-color_icon_(2024).svg/32px-YouTube_full-color_icon_(2024).svg.png',
   },
 };
 

--- a/components/dashboard/sidebar.tsx
+++ b/components/dashboard/sidebar.tsx
@@ -24,7 +24,11 @@ export function Sidebar() {
     <>
       <SidebarHeader>
         <Link href="/dashboard" className="flex items-center gap-2">
-          <img src="/placeholder-logo.svg" alt="Logo" className="h-8 w-8" />
+          <img
+            src="https://upload.wikimedia.org/wikipedia/commons/2/20/YouTube_2024.svg"
+            alt="Logo"
+            className="h-8 w-8"
+          />
           <span className="text-lg font-semibold">AI Studio</span>
         </Link>
       </SidebarHeader>


### PR DESCRIPTION
This commit addresses two issues reported by the user:
- The main layout container is now full width on all screens.
- The placeholder logo and favicon have been replaced with the official YouTube icon.