### PR TITLE
feat: Implement skeleton screens for a premium loading experience

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -13,6 +13,7 @@ import { useSession } from "@/contexts/session-context"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
 import { Loader2 } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export default function DashboardLayout({
   children,
@@ -30,8 +31,43 @@ export default function DashboardLayout({
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <div className="flex h-screen w-full items-center justify-center">
+        <div className="flex h-full w-full flex-col">
+          <div className="border-b">
+            <div className="flex h-16 items-center px-4">
+              <div className="flex-1">
+                <Skeleton className="h-5 w-[200px]" />
+              </div>
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-8 rounded-full" />
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-1">
+            <div className="hidden h-full w-64 border-r md:block">
+              <div className="space-y-4 py-4">
+                <div className="px-3 py-2">
+                  <Skeleton className="h-4 w-20" />
+                  <div className="mt-4 space-y-1">
+                    <Skeleton className="h-8 w-full" />
+                    <Skeleton className="h-8 w-full" />
+                    <Skeleton className="h-8 w-full" />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <main className="flex-1 overflow-y-auto bg-gray-50 p-4 dark:bg-gray-900 md:p-6 lg:p-8">
+              <div className="space-y-4">
+                <Skeleton className="h-8 w-48" />
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  <Skeleton className="h-32 w-full" />
+                  <Skeleton className="h-32 w-full" />
+                  <Skeleton className="h-32 w-full" />
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
       </div>
     )
   }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -13,6 +13,7 @@ import { useSession } from "@/contexts/session-context"
 import { useRouter } from "next/navigation"
 import { useEffect } from "react"
 import { Loader2 } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export default function DashboardLayout({
   children,
@@ -30,8 +31,43 @@ export default function DashboardLayout({
 
   if (isLoading) {
     return (
-      <div className="flex h-screen items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <div className="flex h-screen w-full items-center justify-center">
+        <div className="flex h-full w-full flex-col">
+          <div className="border-b">
+            <div className="flex h-16 items-center px-4">
+              <div className="flex-1">
+                <Skeleton className="h-5 w-[200px]" />
+              </div>
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-8 rounded-full" />
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-1">
+            <div className="hidden h-full w-64 border-r md:block">
+              <div className="space-y-4 py-4">
+                <div className="px-3 py-2">
+                  <Skeleton className="h-4 w-20" />
+                  <div className="mt-4 space-y-1">
+                    <Skeleton className="h-8 w-full" />
+                    <Skeleton className="h-8 w-full" />
+                    <Skeleton className="h-8 w-full" />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <main className="flex-1 overflow-y-auto bg-gray-50 p-4 dark:bg-gray-900 md:p-6 lg:p-8">
+              <div className="space-y-4">
+                <Skeleton className="h-8 w-48" />
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  <Skeleton className="h-32 w-full" />
+                  <Skeleton className="h-32 w-full" />
+                  <Skeleton className="h-32 w-full" />
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
       </div>
     )
   }

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArrowUpRight, Users, Video, Eye, ThumbsUp, MessageSquare, Loader2 } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
 import type { YouTubeChannel } from "@/lib/db"
 
 interface OverviewTabProps {
@@ -66,8 +67,47 @@ export function OverviewTab({ channelData, isLoading }: OverviewTabProps) {
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {[...Array(6)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-4 w-4" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-6 w-1/2" />
+              <Skeleton className="mt-2 h-3 w-1/3" />
+            </CardContent>
+          </Card>
+        ))}
+        <Card className="md:col-span-2 lg:col-span-3">
+          <CardHeader>
+            <Skeleton className="h-6 w-1/3" />
+            <Skeleton className="mt-2 h-4 w-2/3" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <Skeleton className="h-4 w-1/4" />
+                  <Skeleton className="mt-2 h-4 w-3/4" />
+                </div>
+                <div>
+                  <Skeleton className="h-4 w-1/4" />
+                  <Skeleton className="mt-2 h-4 w-3/4" />
+                </div>
+                <div>
+                  <Skeleton className="h-4 w-1/4" />
+                  <Skeleton className="mt-2 h-4 w-3/4" />
+                </div>
+                <div>
+                  <Skeleton className="h-4 w-1/4" />
+                  <Skeleton className="mt-2 h-4 w-3/4" />
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }

--- a/components/dashboard/videos-tab.tsx
+++ b/components/dashboard/videos-tab.tsx
@@ -6,6 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Eye, ThumbsUp, MessageSquare, Loader2, Search, Filter } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useRouter } from "next/navigation"
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
@@ -123,8 +124,36 @@ export function VideosTab({ channelData, isLoading }: VideosTabProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <Loader2 className="h-8 w-8 animate-spin" />
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-1/4" />
+            <Skeleton className="mt-2 h-4 w-2/3" />
+          </CardHeader>
+          <CardContent>
+            <div className="mb-6 flex flex-col gap-4 sm:flex-row">
+              <Skeleton className="h-10 flex-1" />
+              <Skeleton className="h-10 w-full sm:w-[180px]" />
+            </div>
+            <div className="space-y-2">
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <Skeleton className="h-10 w-16" />
+                    <div className="space-y-1">
+                      <Skeleton className="h-4 w-48" />
+                      <Skeleton className="h-3 w-32" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-4 w-12" />
+                  <Skeleton className="hidden h-4 w-12 md:block" />
+                  <Skeleton className="hidden h-4 w-12 md:block" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     )
   }
@@ -178,8 +207,22 @@ export function VideosTab({ channelData, isLoading }: VideosTabProps) {
           </div>
 
           {isLoadingVideos ? (
-            <div className="flex h-[200px] items-center justify-center">
-              <Loader2 className="h-8 w-8 animate-spin" />
+            <div className="space-y-2">
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <div className="flex items-center gap-4">
+                    <Skeleton className="h-10 w-16" />
+                    <div className="space-y-1">
+                      <Skeleton className="h-4 w-48" />
+                      <Skeleton className="h-3 w-32" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-4 w-12" />
+                  <Skeleton className="hidden h-4 w-12 md:block" />
+                  <Skeleton className="hidden h-4 w-12 md:block" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              ))}
             </div>
           ) : filteredVideos.length === 0 ? (
             <div className="flex h-[200px] flex-col items-center justify-center rounded-md border border-dashed p-8 text-center">


### PR DESCRIPTION
This commit replaces the existing loading spinners with skeleton screens to provide a more premium and user-friendly loading experience. Skeleton screens show a placeholder preview of the content, which gives the user a better sense of what's to come.

- Replaced `Loader2` components with `Skeleton` components in the main dashboard layouts and key dashboard tabs.
- Designed the skeleton screens to mimic the layout of the content being loaded.