### PR TITLE
fix(videos): Correctly fetch and display YouTube videos

### DIFF
--- a/components/tabs/videos-tab.tsx
+++ b/components/tabs/videos-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { PlusCircle, Search, SlidersHorizontal, Loader2 } from "lucide-react"
+import { useYouTubeChannel } from "@/contexts/youtube-channel-context"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -28,6 +29,7 @@ export function VideosTab() {
   const [videos, setVideos] = useState<Video[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const { channel } = useYouTubeChannel()
 
   // Form state for new video
   const [newVideoTitle, setNewVideoTitle] = useState("")
@@ -37,7 +39,7 @@ export function VideosTab() {
   const fetchVideos = async () => {
     setIsLoading(true)
     try {
-      const data = await getVideos(searchQuery, filter)
+      const data = await getVideos(channel?.access_token ?? null, searchQuery, filter)
       setVideos(data)
     } catch (error) {
       toast.error("Error", {
@@ -55,7 +57,7 @@ export function VideosTab() {
     }, 300)
 
     return () => clearTimeout(handler)
-  }, [searchQuery, filter])
+  }, [searchQuery, filter, channel])
 
   const handleCreateVideo = async () => {
     if (!newVideoTitle.trim()) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -272,23 +272,25 @@ export async function getVideos(
     const data = await fetchFromYouTubeAPI(query, token)
 
     // Map the response to our Video type
-    let videos = data.items.map((item: any) => ({
+    let videos = (data.items || []).map((item: any) => ({
       id: item.id,
-      thumbnail_url: item.snippet.thumbnails.medium.url,
-      title: item.snippet.title,
+      thumbnail_url: item.snippet?.thumbnails?.medium?.url || "/placeholder.svg",
+      title: item.snippet?.title || "Untitled Video",
       status:
-        item.status.privacyStatus === "public"
+        item.status?.privacyStatus === "public"
           ? "Published"
-          : item.status.privacyStatus === "private"
+          : item.status?.privacyStatus === "private"
           ? "Draft"
           : "Scheduled",
-      views: Number.parseInt(item.statistics.viewCount, 10),
-      likes: Number.parseInt(item.statistics.likeCount, 10),
-      comments: Number.parseInt(item.statistics.commentCount, 10),
-      publishedAt: new Date(item.snippet.publishedAt).toLocaleDateString(),
-      description: item.snippet.description,
-      tags: item.snippet.tags || [],
-    }))
+      views: Number.parseInt(item.statistics?.viewCount || "0", 10),
+      likes: Number.parseInt(item.statistics?.likeCount || "0", 10),
+      comments: Number.parseInt(item.statistics?.commentCount || "0", 10),
+      publishedAt: item.snippet?.publishedAt
+        ? new Date(item.snippet.publishedAt).toLocaleDateString()
+        : "N/A",
+      description: item.snippet?.description || "",
+      tags: item.snippet?.tags || [],
+    }));
 
     // Apply search filter if provided
     if (search) {
@@ -313,25 +315,30 @@ export async function getVideos(
 }
 
 // Helper function to get mock videos (for fallback)
-function getMockVideos(search?: string, filter?: string): Promise<Video[]> {
-  // Use the existing mock data logic
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      let filteredVideos = [...mockVideos]
-      
-      console.log("Mock videos being returned:", filteredVideos)
+async function getMockVideos(search?: string, filter?: string): Promise<Video[]> {
+  await delay(500) // Simulate network delay
 
-      if (search) {
-        filteredVideos = filteredVideos.filter((video) => video.title.toLowerCase().includes(search.toLowerCase()))
-      }
+  console.log("getMockVideos called with search:", search, "filter:", filter)
 
-      if (filter && filter !== "all") {
-        filteredVideos = filteredVideos.filter((video) => video.status.toLowerCase() === filter.toLowerCase())
-      }
+  let videos = [...mockVideos]
 
-      resolve(filteredVideos)
-    }, 800)
-  })
+  // Apply search filter if provided
+  if (search) {
+    videos = videos.filter((video) =>
+      video.title.toLowerCase().includes(search.toLowerCase())
+    )
+  }
+
+  // Apply status filter if provided
+  if (filter && filter !== "all") {
+    videos = videos.filter(
+      (video) => video.status.toLowerCase() === filter.toLowerCase()
+    )
+  }
+
+  console.log("Returning mock videos:", videos)
+
+  return videos
 }
 
 export async function getVideo(id: string): Promise<Video | null> {


### PR DESCRIPTION
This commit fixes an issue where the /videos page would show 'No video found'.

The `VideosTab` component now retrieves the YouTube access token from the `useYouTubeChannel` context and passes it to the `getVideos` API function.

The `getVideos` function in `lib/api.ts` has been made more robust. The mapping logic for the YouTube API response now uses optional chaining and default values to prevent runtime errors when the API response is missing optional fields. This ensures that the application can gracefully handle varied API responses without crashing and falling back to mock data.