### PR TITLE
feat: Replace loading text with skeleton loader

### DIFF
--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+    </div>
+  )
+}

--- a/components/youtube-callback-wrapper.tsx
+++ b/components/youtube-callback-wrapper.tsx
@@ -2,6 +2,7 @@
 
 import React, { Suspense } from "react"
 import YouTubeCallbackContent from "@/components/youtube-callback-content"
+import Loading from "./loading"
 
 // Wrapper component that handles the useSearchParams call
 function YouTubeCallbackInner() {
@@ -11,7 +12,7 @@ function YouTubeCallbackInner() {
 // Main wrapper with Suspense boundary
 export function YouTubeCallbackWrapper() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<Loading />}>
       <YouTubeCallbackInner />
     </Suspense>
   )


### PR DESCRIPTION
Replaces the 'Loading...' text in the YouTube callback wrapper with a skeleton loader to prevent a flash of unstyled content on hard refresh.