### PR TITLE
fix(videos): Optimize video sync to fetch only new videos

### DIFF
--- a/app/api/youtube/videos/sync/route.ts
+++ b/app/api/youtube/videos/sync/route.ts
@@ -48,11 +48,11 @@ async function refreshAccessToken(refreshToken: string) {
   return data.access_token
 }
 
-async function fetchAllVideos(accessToken: string, uploadsPlaylistId: string) {
+async function fetchAllVideos(accessToken: string, uploadsPlaylistId: string, existingVideoIds: Set<string>) {
   let allVideos: any[] = []
   let nextPageToken: string | null = null
   let pageCount = 0
-  const maxPages = 10 // Limit to prevent excessive API calls
+  let foundExistingVideo = false
 
   do {
     pageCount++
@@ -82,16 +82,22 @@ async function fetchAllVideos(accessToken: string, uploadsPlaylistId: string) {
     console.log(`Fetched ${data.items?.length || 0} videos from page ${pageCount}`)
     
     if (data.items) {
-      allVideos = [...allVideos, ...data.items]
+      for (const item of data.items) {
+        if (existingVideoIds.has(item.snippet.resourceId.videoId)) {
+          foundExistingVideo = true
+          break
+        }
+        allVideos.push(item)
+      }
     }
     
-    nextPageToken = data.nextPageToken
-
-    // Break if we've reached the maximum number of pages
-    if (pageCount >= maxPages) {
-      console.log(`Reached maximum page limit (${maxPages})`)
+    if (foundExistingVideo) {
+      console.log('Found existing video, stopping fetch.')
       break
     }
+
+    nextPageToken = data.nextPageToken
+
   } while (nextPageToken)
 
   return allVideos
@@ -216,9 +222,21 @@ export async function POST(request: Request) {
     const uploadsPlaylistId = channelData.items[0].contentDetails.relatedPlaylists.uploads
     console.log('Found uploads playlist:', uploadsPlaylistId)
 
+    // Get existing video IDs to avoid re-fetching
+    const { data: existingVideos, error: existingVideosError } = await supabase
+      .from('youtube_videos')
+      .select('video_id')
+      .eq('channel_id', channel.id)
+
+    if (existingVideosError) {
+      console.error('Error fetching existing videos:', existingVideosError)
+      // Not fatal, so we just log it
+    }
+    const existingVideoIds = new Set(existingVideos?.map(v => v.video_id) || [])
+
     // Fetch all videos from the uploads playlist
-    const playlistItems = await fetchAllVideos(accessToken, uploadsPlaylistId)
-    console.log(`Total videos found: ${playlistItems.length}`)
+    const playlistItems = await fetchAllVideos(accessToken, uploadsPlaylistId, existingVideoIds)
+    console.log(`Total new videos found: ${playlistItems.length}`)
 
     if (playlistItems.length === 0) {
       console.log('No videos found in playlist')


### PR DESCRIPTION
The previous video synchronization logic fetched all videos from the channel on every sync, which was inefficient and could fail to sync new videos if the channel had a large number of videos due to a hardcoded page limit.

This commit optimizes the video synchronization process by:
1.  Fetching the IDs of existing videos from the database before calling the YouTube API.
2.  Paginating through the YouTube API results and stopping as soon as a video is found that already exists in the database.

This ensures that only new videos are fetched and processed, making the synchronization faster and more reliable.